### PR TITLE
Potential fix for code scanning alert no. 73: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/middleware/apiAuth.ts
+++ b/track-server/src/middleware/apiAuth.ts
@@ -15,7 +15,7 @@ export const apiAuth = async (req: Request, res: Response, next: NextFunction) =
     console.log('Authenticating with API key:', apiKey); // 添加调试日志
     
     // 查找拥有该 API 密钥的用户
-    const user = await User.findOne({ apiKey });
+    const user = await User.findOne({ apiKey: { $eq: apiKey } });
     
     console.log('User found:', user ? 'yes' : 'no'); // 添加调试日志
     


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/73](https://github.com/wewb/Nomad/security/code-scanning/73)

To fix the issue, we need to ensure that the `apiKey` is treated as a literal value in the query. This can be achieved by using MongoDB's `$eq` operator, which forces the query to interpret the value as a literal. Alternatively, we can validate the `apiKey` to ensure it is a string before using it in the query.

The best approach here is to use the `$eq` operator in the query. This ensures that even if the `apiKey` is a malicious object, it will be treated as a literal value and not as a query object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
