### PR TITLE
Potential fix for code scanning alert no. 75: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/routes/auth.ts
+++ b/track-server/src/routes/auth.ts
@@ -36,8 +36,13 @@ router.post('/login', loginRateLimiter, async (req, res) => {
       return res.status(400).json({ error: 'Email and password are required' });
     }
 
+    // 验证 email 格式
+    if (typeof email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return res.status(400).json({ error: 'Invalid email format' });
+    }
+
     // 查找用户
-    const user = await User.findOne({ email, isActive: true });
+    const user = await User.findOne({ email: { $eq: email }, isActive: true });
     if (!user) {
       return res.status(401).json({ error: 'Invalid credentials' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/75](https://github.com/wewb/Nomad/security/code-scanning/75)

To fix the issue, we need to ensure that the `email` field is properly sanitized or validated before being used in the MongoDB query. The best approach is to validate the `email` field to ensure it is a string and matches the expected format of an email address. This can be achieved using a library like `validator` or by implementing a custom validation function. Additionally, we can use MongoDB's `$eq` operator to ensure that the `email` field is treated as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
