### PR TITLE
Potential fix for code scanning alert no. 74: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/middleware/validate.ts
+++ b/track-server/src/middleware/validate.ts
@@ -16,7 +16,10 @@ export const validateCreateUser = async (req: Request, res: Response, next: Next
     req.body = req.body.fields;
   }
 
-  const existingUser = await User.findOne({ email });
+  if (typeof email !== 'string') {
+    return res.status(400).json({ error: 'Invalid email format' });
+  }
+  const existingUser = await User.findOne({ email: { $eq: email } });
   if (existingUser) {
     return res.status(400).json({ error: 'Email already exists' });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/74](https://github.com/wewb/Nomad/security/code-scanning/74)

To fix the issue, we need to ensure that the `email` field is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which forces MongoDB to interpret the value as a literal rather than a query object. Additionally, we should validate that `email` is a string before using it in the query. This approach ensures that the query is safe from NoSQL injection attacks.

Changes to make:
1. Use the `$eq` operator in the query to ensure `email` is treated as a literal.
2. Add a validation step to check that `email` is a string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
