### PR TITLE
Potential fix for code scanning alert no. 78: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -15,6 +15,12 @@ const DEBOUNCE_TIME = 500;  // 防抖时间 500ms
 async function validateEndpoint(req: Request, res: Response, next: NextFunction) {
   try {
     const { projectId } = req.body;
+    
+    // Validate projectId
+    if (typeof projectId !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(projectId)) {
+      console.log('Invalid projectId:', projectId);
+      return res.status(400).json({ error: 'Invalid projectId' });
+    }
     const referer = req.headers.referer || req.headers.origin;
     
     if (!referer) {
@@ -23,7 +29,7 @@ async function validateEndpoint(req: Request, res: Response, next: NextFunction)
     }
 
     // 查找项目及其授权端点
-    const project = await Project.findOne({ projectId }).populate('endpoints');
+    const project = await Project.findOne({ projectId: { $eq: projectId } }).populate('endpoints');
     if (!project) {
       console.log('Project not found:', projectId);
       return res.status(404).json({ error: 'Project not found' });


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/78](https://github.com/wewb/Nomad/security/code-scanning/78)

To fix the issue, we need to ensure that the `projectId` value is sanitized or validated before it is used in the MongoDB query. The best approach is to validate that `projectId` is a string and does not contain any unexpected characters or structures. Additionally, we can use MongoDB's `$eq` operator to ensure that the value is treated as a literal.

Steps to fix:
1. Validate that `req.body.projectId` is a string and meets the expected format (e.g., alphanumeric).
2. Use the `$eq` operator in the query to ensure that `projectId` is treated as a literal value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
