### PR TITLE
Potential fix for code scanning alert no. 79: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -31,8 +31,15 @@ router.post('/login', async (req, res) => {
       return res.status(400).json({ error: 'Email and password are required' });
     }
 
+    // 验证 email 格式
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (typeof email !== 'string' || !emailRegex.test(email)) {
+      console.log('Invalid email format');
+      return res.status(400).json({ error: 'Invalid email format' });
+    }
+
     // 查找用户
-    const user = await User.findOne({ email, isActive: true });
+    const user = await User.findOne({ email: { $eq: email }, isActive: true });
     console.log('User found:', user ? 'yes' : 'no');
 
     if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/79](https://github.com/wewb/Nomad/security/code-scanning/79)

To fix the issue, we need to ensure that the `email` field is treated as a literal value in the query. This can be achieved by using MongoDB's `$eq` operator, which forces the query to interpret the input as a literal value rather than a query object. Additionally, we should validate the `email` field to ensure it is a string and conforms to the expected format (e.g., a valid email address).

Steps to fix:
1. Use the `$eq` operator in the query to ensure the `email` field is treated as a literal value.
2. Add validation to check that the `email` field is a string and matches the expected email format.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
