### PR TITLE
Potential fix for code scanning alert no. 76: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -71,8 +71,13 @@ router.post('/', auth, restrictToAdmin, async (req, res) => {
   try {
     const { projectId, name, description, endpoints } = req.body;
 
+    // Validate projectId
+    if (typeof projectId !== 'string') {
+      return res.status(400).json({ error: 'Invalid projectId' });
+    }
+
     // 检查 projectId 是否已存在
-    const existingProject = await Project.findOne({ projectId });
+    const existingProject = await Project.findOne({ projectId: { $eq: projectId } });
     if (existingProject) {
       return res.status(400).json({ error: 'Project ID already exists' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/76](https://github.com/wewb/Nomad/security/code-scanning/76)

To fix the issue, we need to ensure that the `projectId` value from `req.body` is sanitized or validated before being used in the MongoDB query. The best approach is to use MongoDB's `$eq` operator to explicitly treat the input as a literal value, preventing it from being interpreted as a query object. Additionally, we can validate that `projectId` is a string to further reduce the risk of injection.

Steps to implement the fix:
1. Modify the query on line 75 to use the `$eq` operator.
2. Add a validation step to ensure `projectId` is a string before proceeding with the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
