### PR TITLE
Potential fix for code scanning alert no. 80: Database query built from user-controlled sources

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -118,9 +118,15 @@ router.post('/', auth, adminOnly, validateCreateUser, async (req: Request, res: 
 // 更新用户状态 (仅管理员)
 router.patch('/:id/status', auth, adminOnly, async (req, res) => {
   try {
+    // Validate that isActive is a boolean
+    const isActive = req.body.isActive;
+    if (typeof isActive !== 'boolean') {
+      return res.status(400).json({ error: 'Invalid value for isActive' });
+    }
+
     const user = await User.findByIdAndUpdate(
       req.params.id,
-      { isActive: req.body.isActive },
+      { isActive: { $eq: isActive } },
       { new: true }
     ).select('-password');
     


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/80](https://github.com/wewb/Nomad/security/code-scanning/80)

To fix the issue, we need to ensure that the `req.body.isActive` value is validated and sanitized before it is used in the query object. Specifically:
1. Validate that `req.body.isActive` is a boolean value. If it is not, return an error response to the client.
2. Use the `$eq` operator in the query to ensure that the value is treated as a literal and not as a query object.

This fix ensures that the user-provided value is safe to use in the database query and prevents NoSQL injection attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
