### PR TITLE
Potential fix for code scanning alert no. 57: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -244,7 +244,13 @@ router.get('/list', auth, async (req, res) => {
 });
 
 // 删除事件
-router.delete('/:id', auth, restrictToAdmin, async (req, res) => {
+const deleteRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per windowMs
+  message: { error: 'Too many delete requests, please try again later.' },
+});
+
+router.delete('/:id', deleteRateLimiter, auth, restrictToAdmin, async (req, res) => {
   try {
     const event = await Event.findById(req.params.id);
     if (!event) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/57](https://github.com/wewb/Nomad/security/code-scanning/57)

To address the issue, we will add rate limiting to the `/delete/:id` route. We will use the `express-rate-limit` package, which is already imported in the file. A rate limiter will be configured to allow a maximum of 10 requests per minute for this route. This limit is reasonable for an administrative operation like deleting events and will help mitigate potential abuse.

The rate limiter will be applied specifically to the `/delete/:id` route by adding it as middleware before the route handler. This ensures that the rate limiting is scoped to this route and does not affect other parts of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
