### PR TITLE
Potential fix for code scanning alert no. 45: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -82,7 +82,13 @@ router.post('/login', async (req, res) => {
 });
 
 // 获取用户列表 (仅管理员)
-router.get('/', auth, adminOnly, async (req, res) => {
+const getUsersLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.get('/', auth, adminOnly, getUsersLimiter, async (req, res) => {
   try {
     const users = await User.find().select('-password');
     res.json(users);


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/45](https://github.com/wewb/Nomad/security/code-scanning/45)

To address the issue, we will add a rate limiter specifically for the `GET /` route. This will limit the number of requests an IP address can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file. The rate limiter will be configured to allow a maximum of 100 requests per 15 minutes, consistent with the existing rate limiters in the codebase.

Steps:
1. Define a new rate limiter (`getUsersLimiter`) for the `GET /` route.
2. Apply the rate limiter as middleware to the route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
