### PR TITLE
Potential fix for code scanning alert no. 92: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -88,7 +88,7 @@ const getUsersLimiter = rateLimit({
   message: { error: 'Too many requests, please try again later.' },
 });
 
-router.get('/', auth, adminOnly, getUsersLimiter, async (req, res) => {
+router.get('/', getUsersLimiter, auth, adminOnly, async (req, res) => {
   try {
     const users = await User.find().select('-password');
     res.json(users);


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/92](https://github.com/wewb/Nomad/security/code-scanning/92)

To fix the issue, we will ensure that the `auth` middleware is rate-limited. This can be achieved by applying a rate limiter to the route that uses the `auth` middleware. Since the `getUsersLimiter` rate limiter is already applied to the route, we will confirm that it covers all middleware and handlers, including `auth`. If it does not, we will add a separate rate limiter specifically for the `auth` middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
