### PR TITLE
Potential fix for code scanning alert no. 70: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -373,7 +373,13 @@ router.get('/:id', auth, async (req, res) => {
 });
 
 // 获取错误统计数据
-router.get('/stats/errors', auth, async (req: Request, res: Response) => {
+const statsErrorsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.get('/stats/errors', auth, statsErrorsLimiter, async (req: Request, res: Response) => {
   try {
     const user = req.user as unknown as UserDocument;
     const query: any = {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/70](https://github.com/wewb/Nomad/security/code-scanning/70)

To address the issue, we will add a rate-limiting middleware to the `/stats/errors` route. This will limit the number of requests a client can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to define a rate limiter. The rate limiter will be configured to allow a maximum of 100 requests per 15 minutes per IP address, similar to the existing rate limiter for the `/stats/total` route.

The changes will involve:
1. Defining a new rate limiter specifically for the `/stats/errors` route.
2. Applying the rate limiter middleware to the `/stats/errors` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
