### PR TITLE
Potential fix for code scanning alert no. 55: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -222,7 +222,14 @@ router.get('/stats', async (req: Request, res: Response) => {
 });
 
 // 获取事件列表
-router.get('/list', auth, async (req, res) => {
+// Rate limiter for the /list route
+const listRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests to /list, please try again later.' },
+});
+
+router.get('/list', auth, listRateLimiter, async (req, res) => {
   try {
     const user = req.user;
     const query: any = {};


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/55](https://github.com/wewb/Nomad/security/code-scanning/55)

To fix the issue, we will add rate limiting to the `/list` route using the `express-rate-limit` package, which is already imported in the file. We will define a new rate limiter specifically for the `/list` route, limiting the number of requests per IP address to a reasonable threshold (e.g., 100 requests per 15 minutes). This will prevent excessive requests to the route while maintaining functionality for legitimate users.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
