### PR TITLE
Potential fix for code scanning alert no. 52: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -154,7 +154,13 @@ router.patch('/:id/status', updateUserStatusLimiter, auth, adminOnly, async (req
 });
 
 // 生成 API Key
-router.get('/key', auth, async (req, res) => {
+const getKeyLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' }
+});
+
+router.get('/key', getKeyLimiter, auth, async (req, res) => {
   try {
     const user = await User.findById(req.user!._id);
     if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/52](https://github.com/wewb/Nomad/security/code-scanning/52)

To fix the issue, we will introduce a rate-limiting middleware specifically for the `/key` route. The `express-rate-limit` package is already imported in the file, so we can define a rate limiter with appropriate settings (e.g., a maximum number of requests per minute) and apply it to the route. This ensures that the database access is protected from abuse while maintaining the functionality of the endpoint.

Steps:
1. Define a rate limiter using `express-rate-limit` with a reasonable configuration (e.g., 10 requests per minute).
2. Apply the rate limiter to the `/key` route by adding it as middleware before the route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
