### PR TITLE
Potential fix for code scanning alert no. 67: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -361,7 +361,14 @@ router.get('/stats/total', auth, statsTotalLimiter, async (req, res) => {
 });
 
 // 获取单个事件详情
-router.get('/:id', auth, async (req, res) => {
+// Rate limiter for the /stats/:id route
+const statsIdLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.get('/:id', auth, statsIdLimiter, async (req, res) => {
   try {
     // 确保不是 'list' 路径
     if (req.params.id === 'list') {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/67](https://github.com/wewb/Nomad/security/code-scanning/67)

To fix the issue, we will add rate limiting to the `/stats/:id` route using the `express-rate-limit` middleware. This will ensure that the number of requests to this route is capped within a specified time window, preventing potential abuse. We will define a new rate limiter specifically for this route, similar to the one used for `/stats/total`. The rate limiter will restrict each IP to a maximum of 100 requests per 15-minute window and return a "Too many requests" error message if the limit is exceeded.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
