### PR TITLE
Potential fix for code scanning alert no. 53: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -187,7 +187,13 @@ router.get('/key', getKeyLimiter, auth, async (req, res) => {
 });
 
 // 创建新的API密钥 (如果已存在则替换)
-router.post('/key', auth, async (req, res) => {
+const postKeyLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' }
+});
+
+router.post('/key', postKeyLimiter, auth, async (req, res) => {
   try {
     const { name } = req.body;
     if (!name) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/53](https://github.com/wewb/Nomad/security/code-scanning/53)

To fix the issue, we will add a rate-limiting middleware to the `/key` POST route, similar to the one already applied to the `/key` GET route. This middleware will limit the number of requests a user can make to this route within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to define a new rate limiter specifically for the `/key` POST route. The rate limiter will restrict each IP to a maximum of 10 requests per minute, and an appropriate error message will be returned if the limit is exceeded.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
