### PR TITLE
Potential fix for code scanning alert no. 95: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -368,7 +368,7 @@ const statsIdLimiter = rateLimit({
   message: { error: 'Too many requests, please try again later.' },
 });
 
-router.get('/:id', auth, statsIdLimiter, async (req, res) => {
+router.get('/:id', statsIdLimiter, auth, async (req, res) => {
   try {
     // 确保不是 'list' 路径
     if (req.params.id === 'list') {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/95](https://github.com/wewb/Nomad/security/code-scanning/95)

To address the issue, we need to ensure that the `auth` middleware is executed only after the rate limiter. This can be achieved by reordering the middleware in the route definition so that `statsIdLimiter` is applied before `auth`. This ensures that the rate limiter blocks excessive requests before the `auth` middleware is executed, mitigating the risk of a DoS attack.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
