### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/track-server/src/routes/api.ts
+++ b/track-server/src/routes/api.ts
@@ -20,7 +20,7 @@ router.get('/test', (req, res) => {
 });
 
 // 获取用户列表 (仅管理员)
-router.get('/users/list', apiAuth, apiAdminOnly, async (req, res) => {
+router.get('/users/list', appRateLimiter, apiAuth, apiAdminOnly, async (req, res) => {
   try {
     const users = await User.find().select('-password -apiKey');
     res.json(users);


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/13](https://github.com/wewb/Nomad/security/code-scanning/13)

To address the issue, we will apply a rate limiter to the `/users/list` route. This can be achieved by reusing the existing `appRateLimiter` middleware, which is already defined in the file and limits requests to 100 per 15 minutes. This ensures consistency across the application and avoids introducing redundant configurations.

The fix involves adding `appRateLimiter` as middleware to the `/users/list` route. This change will limit the rate at which requests can be made to this endpoint, mitigating the risk of abuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
