### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/track-server/src/routes/auth.ts
+++ b/track-server/src/routes/auth.ts
@@ -78,7 +78,7 @@ const logoutRateLimiter = rateLimit({
   message: { error: 'Too many logout attempts. Please try again later.' },
 });
 
-router.post('/logout', auth, logoutRateLimiter, async (req, res) => {
+router.post('/logout', logoutRateLimiter, auth, async (req, res) => {
   try {
     const user = await User.findById(req.user!._id);
     if (!user) {

--- a/track-server/src/routes/auth.ts
+++ b/track-server/src/routes/auth.ts
@@ -72,7 +72,13 @@ router.post('/login', loginRateLimiter, async (req, res) => {
 });
 
 // 用户登出
-router.post('/logout', auth, async (req, res) => {
+const logoutRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 5, // Limit each IP to 5 logout requests per `windowMs`
+  message: { error: 'Too many logout attempts. Please try again later.' },
+});
+
+router.post('/logout', auth, logoutRateLimiter, async (req, res) => {
   try {
     const user = await User.findById(req.user!._id);
     if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/14](https://github.com/wewb/Nomad/security/code-scanning/14)

To address the issue, we will add a rate limiter to the `/logout` route. This will limit the number of requests a client can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file (line 5). A new rate limiter configuration will be created specifically for the `/logout` route, similar to the existing `loginRateLimiter`. This configuration will limit each IP to a reasonable number of requests (e.g., 5 requests per minute).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
