### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/track-server/src/routes/auth.ts
+++ b/track-server/src/routes/auth.ts
@@ -7,7 +7,13 @@ import rateLimit from 'express-rate-limit';
 const router = express.Router();
 
 // 获取当前用户信息
-router.get('/me', auth, async (req, res) => {
+const meRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per `windowMs`
+  message: { error: 'Too many requests. Please try again later.' },
+});
+
+router.get('/me', meRateLimiter, auth, async (req, res) => {
   try {
     const user = await User.findById(req.user!._id).select('-password');
     if (!user) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/9](https://github.com/wewb/Nomad/security/code-scanning/9)

To address the issue, we will add a rate limiter to the `/me` route. This will limit the number of requests a single IP can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file. The rate limiter will be configured to allow a reasonable number of requests (e.g., 100 requests per 15 minutes) to balance security and usability.

Steps:
1. Define a new rate limiter specifically for the `/me` route.
2. Apply the rate limiter as middleware to the `/me` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
