### PR TITLE
Potential fix for code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/track-server/src/routes/api.ts
+++ b/track-server/src/routes/api.ts
@@ -31,7 +31,7 @@ router.get('/users/list', appRateLimiter, apiAuth, apiAdminOnly, async (req, res
 });
 
 // 获取应用列表 (根据用户权限)
-router.get('/app/list', apiAuth, async (req, res) => {
+router.get('/app/list', appRateLimiter, apiAuth, async (req, res) => {
   try {
     const user = req.user;
     let projects;


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/16](https://github.com/wewb/Nomad/security/code-scanning/16)

To fix the issue, we will apply the existing `appRateLimiter` middleware to the `/app/list` route. This ensures that the route is protected against excessive requests, limiting the potential for DoS attacks. The fix involves adding `appRateLimiter` to the middleware chain for the `/app/list` route, similar to how it is applied to the `/users/list` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
