### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/track-server/src/routes/api.ts
+++ b/track-server/src/routes/api.ts
@@ -91,7 +91,7 @@ router.get('/app/:id', appRateLimiter, apiAuth, apiCheckProjectAccess, async (re
 });
 
 // 获取应用事件列表 (根据用户权限)
-router.get('/app/:id/events', apiAuth, apiCheckProjectAccess, async (req, res) => {
+router.get('/app/:id/events', appRateLimiter, apiAuth, apiCheckProjectAccess, async (req, res) => {
   try {
     const project = await Project.findById(req.params.id);
     if (!project) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/20](https://github.com/wewb/Nomad/security/code-scanning/20)

To fix the issue, we will add the `appRateLimiter` middleware to the `/app/:id/events` route. This middleware is already defined in the file and is used in other routes to limit the number of requests from a single IP address to 100 requests per 15 minutes. Adding this middleware will ensure that the `/app/:id/events` route is protected against abuse and aligns with the rate-limiting strategy used elsewhere in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
