### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -45,7 +45,13 @@ router.get('/list', listRateLimiter, auth, async (req: Request, res: Response) =
 });
 
 // 获取单个应用详情
-router.get('/:id', auth, async (req: Request, res: Response) => {
+const detailRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.get('/:id', detailRateLimiter, auth, async (req: Request, res: Response) => {
   try {
     const project = await Project.findById(req.params.id);
     if (!project) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/24](https://github.com/wewb/Nomad/security/code-scanning/24)

To fix the issue, we will add a rate limiter to the `/id` route, similar to the one used for the `/list` route. This will limit the number of requests a client can make to this route within a specified time window. We will reuse the `rateLimit` middleware from the `express-rate-limit` package and configure it to allow a maximum of 100 requests per 15 minutes per IP address. This ensures consistency with the `/list` route and provides adequate protection against abuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
