### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -81,7 +81,13 @@ router.get('/:id', detailRateLimiter, auth, async (req: Request, res: Response) 
 });
 
 // 创建新应用
-router.post('/', auth, restrictToAdmin, async (req, res) => {
+const createRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // limit each IP to 50 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.post('/', createRateLimiter, auth, restrictToAdmin, async (req, res) => {
   try {
     const { projectId, name, description, endpoints } = req.body;
 


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/26](https://github.com/wewb/Nomad/security/code-scanning/26)

To fix the issue, we will add a rate-limiting middleware to the `/` POST route. This middleware will limit the number of requests that can be made to the route within a specified time window. We will use the `express-rate-limit` package, which is already imported and used in the file. A new rate limiter will be defined specifically for the `/` POST route, with a configuration similar to the existing rate limiters for consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
