### PR TITLE
Potential fix for code scanning alert no. 33: Missing rate limiting

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -148,7 +148,7 @@ router.put('/:id', auth, restrictToAdmin, async (req: Request, res: Response) =>
 });
 
 // 删除应用
-router.delete('/:id', auth, restrictToAdmin, async (req: Request, res: Response) => {
+router.delete('/:id', listRateLimiter, auth, restrictToAdmin, async (req: Request, res: Response) => {
   try {
     const project = await Project.findByIdAndDelete(req.params.id);
     if (!project) {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/33](https://github.com/wewb/Nomad/security/code-scanning/33)

To fix the issue, we will add a rate limiter to the `DELETE` route. This can be achieved by reusing the existing `listRateLimiter` or creating a new rate limiter specifically for this route. The rate limiter will restrict the number of requests a client can make to the `DELETE` route within a specified time window, reducing the risk of DoS attacks.

Steps:
1. Import the `rateLimit` middleware (already done in the provided code).
2. Define a new rate limiter (if needed) or reuse the existing `listRateLimiter`.
3. Apply the rate limiter to the `DELETE` route by adding it to the middleware chain.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
