### PR TITLE
Potential fix for code scanning alert no. 35: Missing rate limiting

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -166,7 +166,7 @@ router.delete('/:id', listRateLimiter, auth, restrictToAdmin, async (req: Reques
 });
 
 // 添加端点
-router.post('/:id/endpoints', auth, restrictToAdmin, async (req, res) => {
+router.post('/:id/endpoints', listRateLimiter, auth, restrictToAdmin, async (req, res) => {
   try {
     console.log('Adding endpoint to app:', req.params.id, req.body);
     


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/35](https://github.com/wewb/Nomad/security/code-scanning/35)

To fix the issue, we will apply the existing `listRateLimiter` middleware to the `POST /:id/endpoints` route. This middleware limits each IP to 100 requests per 15 minutes, which is consistent with the rate limiting applied to other routes in the file. This ensures uniform security measures across all routes that interact with the database.

**Steps to implement the fix:**
1. Add the `listRateLimiter` middleware to the `POST /:id/endpoints` route.
2. Ensure the middleware is applied before the `auth` and `restrictToAdmin` middlewares to enforce rate limiting before authorization checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
