### PR TITLE
Potential fix for code scanning alert no. 40: Missing rate limiting

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -209,7 +209,7 @@ router.post('/:id/endpoints', listRateLimiter, auth, restrictToAdmin, async (req
 });
 
 // 删除端点
-router.delete('/:id/endpoints/:endpointId', auth, restrictToAdmin, async (req, res) => {
+router.delete('/:id/endpoints/:endpointId', listRateLimiter, auth, restrictToAdmin, async (req, res) => {
   try {
     console.log('Deleting endpoint:', req.params.id, req.params.endpointId);
     


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/40](https://github.com/wewb/Nomad/security/code-scanning/40)

To fix the issue, we will apply the existing `listRateLimiter` middleware to the `DELETE /:id/endpoints/:endpointId` route. This ensures that the route is protected against excessive requests, similar to the `POST /:id/endpoints` route. The `listRateLimiter` is already defined and imported, so no additional dependencies or configurations are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
