### PR TITLE
Potential fix for code scanning alert no. 43: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -27,7 +27,13 @@ const meRateLimiter = rateLimit({
 });
 
 // 用户登录
-router.post('/login', async (req, res) => {
+const loginRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { error: 'Too many login attempts, please try again later.' },
+});
+
+router.post('/login', loginRateLimiter, async (req, res) => {
   try {
     console.log('Login request received:', req.body);
     const { email, password } = req.body;


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/43](https://github.com/wewb/Nomad/security/code-scanning/43)

To fix the issue, we will add a rate limiter specifically for the `/login` route. This will limit the number of requests an IP address can make to this endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to define a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes). The rate limiter will then be applied to the `/login` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
