### PR TITLE
Potential fix for code scanning alert no. 46: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -160,7 +160,14 @@ router.post('/', async (req, res) => {
 });
 
 // 获取统计数据
-router.get('/stats', async (req: Request, res: Response) => {
+// Rate limiter for the /stats route
+const statsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: { error: 'Too many requests to /stats, please try again later.' },
+});
+
+router.get('/stats', statsRateLimiter, async (req: Request, res: Response) => {
   try {
     const { startDate, endDate } = req.query;
     console.log('Stats request:', { startDate, endDate });


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/46](https://github.com/wewb/Nomad/security/code-scanning/46)

To address the issue, we will add a rate-limiting middleware to the `/stats` route. This middleware will limit the number of requests an IP can make to the endpoint within a specified time window. We will use the `express-rate-limit` package, which is already imported in the file, to implement this fix.

The rate limiter will be configured to allow a maximum of 100 requests per 15 minutes per IP address. This configuration strikes a balance between usability and security, ensuring legitimate users can access the endpoint without being overly restricted while mitigating the risk of abuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
