### PR TITLE
Potential fix for code scanning alert no. 82: Missing rate limiting

### DIFF
--- a/track-server/src/routes/application.ts
+++ b/track-server/src/routes/application.ts
@@ -119,7 +119,13 @@ router.post('/', createRateLimiter, auth, restrictToAdmin, async (req, res) => {
 });
 
 // 更新应用
-router.put('/:id', auth, restrictToAdmin, async (req: Request, res: Response) => {
+const updateRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // limit each IP to 50 requests per windowMs
+  message: { error: 'Too many requests, please try again later.' },
+});
+
+router.put('/:id', updateRateLimiter, auth, restrictToAdmin, async (req: Request, res: Response) => {
   try {
     const { name, description } = req.body;
     if (typeof name !== 'string' || typeof description !== 'string') {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/82](https://github.com/wewb/Nomad/security/code-scanning/82)

To fix the issue, we will add a rate limiter to the `PUT` route on line 122. This will involve:
1. Defining a new rate limiter specifically for the `PUT` route, similar to the existing rate limiters for the `GET` and `POST` routes.
2. Applying the new rate limiter middleware to the `PUT` route.

The rate limiter will restrict the number of requests from a single IP address to a reasonable limit (e.g., 50 requests per 15 minutes) to prevent abuse while allowing legitimate usage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
