### PR TITLE
Potential fix for code scanning alert no. 93: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -393,14 +393,14 @@ router.get('/:id', statsIdLimiter, auth, async (req, res) => {
   }
 });
 
-// 获取错误统计数据
+// Rate limiter for the /stats/errors route
 const statsErrorsLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // Limit each IP to 100 requests per windowMs
   message: { error: 'Too many requests, please try again later.' },
 });
 
-router.get('/stats/errors', auth, statsErrorsLimiter, async (req: Request, res: Response) => {
+router.get('/stats/errors', statsErrorsLimiter, auth, async (req: Request, res: Response) => {
   try {
     const user = req.user as unknown as UserDocument;
     const query: any = {


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/93](https://github.com/wewb/Nomad/security/code-scanning/93)

To fix the issue, we will apply a rate limiter to the `/stats/errors` route using the `express-rate-limit` middleware. This will limit the number of requests that can be made to the route from a single IP address within a specified time window. The rate limiter will be configured similarly to the existing rate limiters in the file (e.g., `statsIdLimiter`), ensuring consistency across the codebase.

Steps:
1. Define a new rate limiter (`statsErrorsLimiter`) with appropriate settings (e.g., 100 requests per 15 minutes).
2. Apply the `statsErrorsLimiter` middleware to the `/stats/errors` route, ensuring it is executed before the route handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
