### PR TITLE
Potential fix for code scanning alert no. 86: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -263,7 +263,12 @@ router.delete('/key', auth, meRateLimiter, async (req, res) => {
 });
 
 // 配置用户项目权限
-router.post('/projects', auth, meRateLimiter, adminOnly, async (req: Request, res: Response) => {
+const projectsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50, // Limit each IP to 50 requests per windowMs
+});
+
+router.post('/projects', auth, meRateLimiter, projectsRateLimiter, adminOnly, async (req: Request, res: Response) => {
   try {
     console.log('Received request body:', req.body); // 调试日志
 


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/86](https://github.com/wewb/Nomad/security/code-scanning/86)

To address the issue, we will explicitly add a rate-limiting middleware to the route handler flagged by CodeQL. The `express-rate-limit` package is already imported in the file, so we can use it to define a rate limiter specifically for this route. The rate limiter will restrict the number of requests allowed within a specified time window, mitigating the risk of DoS attacks.

Steps to implement the fix:
1. Define a new rate limiter using `express-rate-limit` for the `/projects` route.
2. Apply the rate limiter to the route handler alongside the existing middlewares (`auth` and `adminOnly`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
