### PR TITLE
Potential fix for code scanning alert no. 97: Missing rate limiting

### DIFF
--- a/track-server/src/routes/user.ts
+++ b/track-server/src/routes/user.ts
@@ -268,7 +268,7 @@ const projectsRateLimiter = rateLimit({
   max: 50, // Limit each IP to 50 requests per windowMs
 });
 
-router.post('/projects', auth, meRateLimiter, projectsRateLimiter, adminOnly, async (req: Request, res: Response) => {
+router.post('/projects', projectsRateLimiter, auth, meRateLimiter, adminOnly, async (req: Request, res: Response) => {
   try {
     console.log('Received request body:', req.body); // 调试日志
 


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/97](https://github.com/wewb/Nomad/security/code-scanning/97)

To fix the issue, we need to ensure that rate limiting is applied before the `auth` middleware on the `/projects` route. This can be achieved by reordering the middleware so that `projectsRateLimiter` is applied first. Additionally, we should verify that the rate limiter is configured appropriately for this route.

Steps:
1. Move the `projectsRateLimiter` middleware to precede the `auth` middleware in the `/projects` route definition.
2. Ensure that the rate limiter configuration (e.g., `windowMs` and `max`) is appropriate for the expected traffic on this route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
