### PR TITLE
Potential fix for code scanning alert no. 94: Missing rate limiting

### DIFF
--- a/track-server/src/routes/track.ts
+++ b/track-server/src/routes/track.ts
@@ -236,7 +236,7 @@ const listRateLimiter = rateLimit({
   message: { error: 'Too many requests to /list, please try again later.' },
 });
 
-router.get('/list', auth, listRateLimiter, async (req, res) => {
+router.get('/list', listRateLimiter, auth, async (req, res) => {
   try {
     const user = req.user;
     const query: any = {};


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/94](https://github.com/wewb/Nomad/security/code-scanning/94)

To fix the issue, the `listRateLimiter` middleware should be applied before the `auth` middleware in the `/list` route. This ensures that rate limiting is enforced before any authorization logic is executed, preventing unnecessary resource consumption for requests that exceed the limit.

Steps to implement the fix:
1. Reorder the middleware in the `/list` route so that `listRateLimiter` is applied before `auth`.
2. Ensure that the functionality of the route remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
