### PR TITLE
Potential fix for code scanning alert no. 99: Clear-text logging of sensitive information

### DIFF
--- a/track-server/src/middleware/apiAuth.ts
+++ b/track-server/src/middleware/apiAuth.ts
@@ -12,7 +12,7 @@ export const apiAuth = async (req: Request, res: Response, next: NextFunction) =
       return res.status(401).json({ error: 'API key is required' });
     }
     
-    console.log('Authenticating with API key:', apiKey); // 添加调试日志
+    console.log('Authenticating with API key'); // 添加调试日志 (API key value redacted)
     
     // 查找拥有该 API 密钥的用户
     const user = await User.findOne({ apiKey: { $eq: apiKey } });


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/99](https://github.com/wewb/Nomad/security/code-scanning/99)

To resolve the issue, you should prevent logging raw sensitive data like an API key. Instead of outputting the API key, logging a generic message indicating an authentication attempt suffices for diagnostic purposes and does not leak secrets. 

Specifically:
- Replace the line logging `apiKey` (line 15) with a generic log message, e.g., "Authenticating with API key (redacted)" or simply "Authenticating with API key" without the actual value.
- You do not need to log any part of the actual API key.
- No new methods or imports are required; simply edit or remove the relevant logging line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
