### PR TITLE
Potential fix for code scanning alert no. 98: Sensitive data read from GET request

### DIFF
--- a/track-server/src/middleware/apiAuth.ts
+++ b/track-server/src/middleware/apiAuth.ts
@@ -5,8 +5,8 @@ import mongoose from 'mongoose';
 // API 密钥认证中间件
 export const apiAuth = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    // 从查询参数中获取 API 密钥
-    const apiKey = req.query.key as string;
+    // 从请求头中获取 API 密钥
+    const apiKey = req.header('x-api-key');
     
     if (!apiKey) {
       return res.status(401).json({ error: 'API key is required' });


### PR DESCRIPTION
Potential fix for [https://github.com/wewb/Nomad/security/code-scanning/98](https://github.com/wewb/Nomad/security/code-scanning/98)

To address this security issue, the API key must not be sent via URL query parameters. Instead, the middleware should expect the client to supply the API key using a secure channel, such as an HTTP header—for instance, `x-api-key`. Modify the `apiAuth` middleware to:
- Extract `apiKey` from `req.header("x-api-key")` instead of from `req.query`.
- If needed, update usage comments/documentation to reflect the new requirement.
- Ensure the fix is only for code in the provided snippet; do not speculate about callers.
- No third-party libraries are needed for this fix; Express's Request interface supports headers natively.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
